### PR TITLE
fix to work with any contextClassLoader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,15 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-core:1.2.10'
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
 
+    // This dependency is required by ConfigurationDelegateTest.appenderSMTP().
+    testImplementation 'com.sun.mail:javax.mail:1.6.2'
+
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
 }
 
-tasks.named('test') {
-    // Use JUnit Platform for unit tests.
-    useJUnitPlatform()
+test {
+    useJUnit()  // Use JUnit 4 for unit tests.
 }
 
 

--- a/src/main/groovy/ch/qos/logback/classic/gaffer/GafferConfigurator.groovy
+++ b/src/main/groovy/ch/qos/logback/classic/gaffer/GafferConfigurator.groovy
@@ -51,7 +51,7 @@ class GafferConfigurator {
     }
 
     void run(String dslText) {
-        ConfigObject config
+        ConfigObject config = null
         Set<String> importsList = [] as Set
         Set<String> staticImportsList = [] as Set
         Set<String> starImportsList = [] as Set
@@ -63,6 +63,9 @@ class GafferConfigurator {
 
         if (inputStream) {
             ConfigSlurper configSlurper = new ConfigSlurper()
+            // In gradle's test compile phases, make sure that the Script class that logbackCompiler.groovy implicitly
+            // extends is the same Script class that ConfigSlurper can match with the parameter for its parse() method.
+            configSlurper.classLoader = new GroovyClassLoader(configSlurper.class.classLoader)
             config = configSlurper.parse(inputStream.text)
         }
 


### PR DESCRIPTION
Avoid MissingMethodException when the contextClassLoader has a different Script class.